### PR TITLE
Copyright message in footer always displays the current year.

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -43,7 +43,7 @@
       </ul>
     </div>
     <div class="footer-element">
-      <p class="copyright">Copyright &copy; Sunrise Movement 2020</p>
+      <p class="copyright">Copyright &copy; Sunrise Movement 2019 - {{ .Now.Year }} </p>
     </div>
   </div>
 </footer>


### PR DESCRIPTION
Using {{ .Now.Year }} to present the copyright range from 2019 to the present.